### PR TITLE
Separated donor name/QTY OCR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 # CRKRelicBot-specific ignores
 # Ignore directories generated for storing screenshots/etc.
 images/[0-9]*
+images/latest
+_planning.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 <!-- PROJECT LOGO -->
 <br />
 <div align="center">
-  <a href="https://github.com/othneildrew/Best-README-Template">
-    <img src="images/logo.png" alt="Logo" width="80" height="80">
+  <a href="https://github.com/vinlyau/crkrelicbot">
+    <img src="images/logo.png" alt="Logo" width="90" height="90">
   </a>
 
   <h3 align="center">CRKRelicBot</h3>

--- a/crkrelicbot/__main__.py
+++ b/crkrelicbot/__main__.py
@@ -1,15 +1,25 @@
 import easyocr
 import os
+import shutil
 import time
 from pprint import pprint
+from string import ascii_lowercase, ascii_uppercase, punctuation, whitespace
 
-from .game_capture import capture_window, crop_to_donors, crop_to_relic_name
+from .game_capture import capture_window, crop_to_donors, crop_to_qtys, crop_to_relic_name
 from .image_utils import process_image_for_ocr
 
 
+# -- Script-required metadata --
 CRK_WINDOW_NAME = 'CookieRun: Kingdom'
 IMAGES_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'images')
 
+# -- Useful Macros --
+KNAME_BLOCKLIST = f'{punctuation}{whitespace}'
+RNAME_ALLOWLIST = f'{ascii_lowercase}{ascii_uppercase}\'-&: '
+RQTYS_ALLOWLIST = 'x0123456789'
+
+# -- Globals --
+# easyocr reader only needs to be initialized once per language combination
 reader = easyocr.Reader(['en'])
 
 
@@ -21,17 +31,21 @@ def process_one_capture(img_dir: str):
     # Crop out relic name and donors list
     relic_name_filepath = crop_to_relic_name(full_filepath)
     donors_filepath = crop_to_donors(full_filepath)
+    qtys_filepath = crop_to_qtys(full_filepath)
 
     # Pre-process images to improve OCR quality
     process_image_for_ocr(relic_name_filepath, invert=True, threshold=150, dilate=False)
     process_image_for_ocr(donors_filepath)
+    process_image_for_ocr(qtys_filepath, threshold=100)
 
     # Run OCR on processed images
     # TODO: pprints to be removed
-    relic_name = reader.readtext(relic_name_filepath, detail=0)
+    relic_name = reader.readtext(relic_name_filepath, allowlist=RNAME_ALLOWLIST, paragraph=True)
     pprint(relic_name)
-    donors_list = reader.readtext(donors_filepath, detail=0)
+    donors_list = reader.readtext(donors_filepath, blocklist=KNAME_BLOCKLIST)
     pprint(donors_list)
+    qtys_list = reader.readtext(qtys_filepath, allowlist=RQTYS_ALLOWLIST)
+    pprint(qtys_list)
 
     # TODO: Add extracted info to sheet/other data storage
 
@@ -41,7 +55,14 @@ def run():
     if not os.path.isdir(run_img_dir):
         os.makedirs(run_img_dir)
 
+    # TODO: change this to a function that will run for all relics/pages
+    #       currently left as-is for testing purposes only
     process_one_capture(run_img_dir)
+
+    # Duplicate the images in a 'latest' directory for convenience
+    # TODO: Add ability to specify CL arg to disable this feature
+    latest_img_dir = os.path.join(IMAGES_DIR, 'latest')
+    shutil.copytree(run_img_dir, latest_img_dir, dirs_exist_ok=True)
 
 
 if __name__ == '__main__':

--- a/crkrelicbot/game_capture.py
+++ b/crkrelicbot/game_capture.py
@@ -62,7 +62,11 @@ def crop_to_region(filepath: str, region_name: str,
 
 
 def crop_to_donors(filepath: str) -> str:
-    return crop_to_region(filepath, 'donors', .585, .27, .86, .58)
+    return crop_to_region(filepath, 'donors', .585, .27, .81, .58)
+
+
+def crop_to_qtys(filepath: str) -> str:
+    return crop_to_region(filepath, 'qtys', .81, .27, .86, .58)
 
 
 def crop_to_relic_name(filepath: str) -> str:


### PR DESCRIPTION
 - Segregated the OCR process for donor names and donated quantities (referred to as qtys, QTYs, RQTYS, etc.) to enhance OCR quality by having greater granularity
 - Changed relic name detection to paragraph style for auto-concatenation of multi-line relic names
 - Increased specificity of OCR by adding blocklists/allowlists as pertinent
 - Added duplicating most recent run's images to a latest directory for convenience of access (e.g., in VSCode you can now leave the image files from latest open and each run will update in VSCode's image browser without needing to reopen new images)
 - Updated readme and .gitignore (minor logistical changes)